### PR TITLE
Parse "machineStatus(cassette)" as an array

### DIFF
--- a/stratasys.py
+++ b/stratasys.py
@@ -36,7 +36,7 @@ def printer_get_data(h,p=53742):
         return outdat;
 
 def objproc(key, value):
-        if(key == "machineStatus(queue)"):
+        if(key == "machineStatus(queue)" or key == "machineStatus(cassette)"):
             v1 = value[1:-1].split('}\t')
             ol=[]
             for i in v1:


### PR DESCRIPTION
"machineStatus(cassette)" basically returns the arrayof spools in the machine, so basically it should be an array.
i checked the return value unparsed, on a Fortus 900mc, "machineStatus(cassette)" has 4 spools.